### PR TITLE
improved color coordinate page

### DIFF
--- a/src/app/color-coordinate.service.ts
+++ b/src/app/color-coordinate.service.ts
@@ -1,0 +1,63 @@
+// This service shares the color state across TableOne and TableTwo components
+import { Injectable } from '@angular/core';
+
+
+@Injectable({ providedIn: 'root' })
+export class ColorCoordinateService {
+    private currentColor: string = '';
+    // sets initial index to nothing selected
+    private selectedRowIndex: number = -1;
+    private rowCoordinates: { [rowIndex: number]: string[] } = {};
+    // tracks TableTwo cell colors
+    private cellColors: { [key: string]: string } = {};
+
+    addCoordinateToRow(rowIndex: number, coordinate: string): void {
+        if (!this.rowCoordinates[rowIndex]) {
+            this.rowCoordinates[rowIndex] = [];
+        }
+        // Check if the coordinate already exists in the row, don't push duplicates
+        if (!this.rowCoordinates[rowIndex].includes(coordinate)) {
+            this.rowCoordinates[rowIndex].push(coordinate);
+        }
+    }
+
+    getCoordinatesForRow(rowIndex: number): string[] {
+        return this.rowCoordinates[rowIndex] || [];
+    }
+
+    // tracks which row in TableOne is active
+    setTableOneRowIndex(index: number): void {
+        this.selectedRowIndex = index;
+    }
+
+    getTableOneRowIndex(): number {
+        return this.selectedRowIndex;
+    }
+
+    setColor(color: string) {
+        this.currentColor = color;
+    }
+
+    getColor(): string {
+        return this.currentColor;
+    }
+
+    setCellColor(cell: string, color: string) {
+        this.cellColors[cell] = color;
+    }
+
+    getCellColor(cell: string): string | undefined {
+        return this.cellColors[cell];
+    }
+
+    updateColorForCells(oldColor: string, newColor: string, coordinates: string[]) {
+        for (const coord of coordinates) {
+            if (this.cellColors[coord] === oldColor) {
+                console.log("updating color to :" + newColor + "for coord: " + coord);
+                this.cellColors[coord] = newColor;
+            }
+        }
+    }
+
+
+}

--- a/src/app/colorcoordinate.component.html
+++ b/src/app/colorcoordinate.component.html
@@ -30,12 +30,12 @@
 </div>
 
 <div id="print-section" *ngIf="tableData">
-  
+
     <h2>Color Coordinate Tables</h2>
-  
+
     <app-table1 [inputData]="tableData"></app-table1>
-    <app-table2 [inputData]="tableData"></app-table2>
-  </div>
+    <app-table2 [inputData]="tableData" style="page-break-before: always;"></app-table2>
+</div>
 
 <div id="error" style="color: red; margin-top: 10px;"></div>
 

--- a/src/app/tableOne.component.html
+++ b/src/app/tableOne.component.html
@@ -3,7 +3,7 @@
         <td class="col-left">
             <div class="screen">
                 <input type="radio" name="selectedRow" [value]="row.index" [checked]="selectedRow === row.index"
-                (change)="setSelectedRow(row.index)" />
+                    (change)="setSelectedRow(row.index)" />
 
                 <select [(ngModel)]="row.selectedColor" [disabled]="selectedRow !== row.index"
                     (change)="onColorChange(row.index, row.selectedColor)">
@@ -14,10 +14,14 @@
             </div>
 
             <div class="print-section">
-                {{ row.selectedColor | titlecase }}  
+                {{ row.selectedColor | titlecase }}
             </div>
         </td>
 
-        <td class="col-right"></td>
+        <td class="col-right" style="text-align: left;">
+            <span [ngStyle]="{ color: selectedRow===row.index ? 'black' : 'gray' }">
+                {{ colorCoordinateService.getCoordinatesForRow(row.index).join(', ') }}
+            </span>
+        </td>
     </tr>
 </table>

--- a/src/app/tableOne.component.ts
+++ b/src/app/tableOne.component.ts
@@ -1,12 +1,12 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { NgForOf, TitleCasePipe } from '@angular/common';
+import { NgForOf, TitleCasePipe, NgIf, NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-
+import { ColorCoordinateService } from './color-coordinate.service';
 
 @Component({
     selector: 'app-table1',
     standalone: true,
-    imports: [NgForOf, FormsModule, TitleCasePipe],
+    imports: [NgForOf, FormsModule, TitleCasePipe, NgIf, NgStyle],
     templateUrl: './tableOne.component.html',
     styleUrls: ['./tableOne.component.css']
 })
@@ -28,9 +28,12 @@ export class TableOneComponent implements OnChanges {
     selectedRow: number | null = null;
 
     // Each row has a color and unique index
-    rows: { index: number, selectedColor: string }[] = [];
+    rows: {
+        index: number,
+        selectedColor: string
+    }[] = [];
 
-    constructor() {
+    constructor(public colorCoordinateService: ColorCoordinateService) {
         // Generate the row list when the component is created
         this.createRowList(this.numberOfRows);
     }
@@ -64,9 +67,31 @@ export class TableOneComponent implements OnChanges {
 
     setSelectedRow(index: number): void {
         this.selectedRow = index;
+
+        const selectedColor = this.rows[index].selectedColor;
+        this.colorCoordinateService.setColor(selectedColor);
+        this.colorCoordinateService.setTableOneRowIndex(index); // tracks active row
+    }
+
+    getRowIndex(): number {
+        return this.selectedRow ?? -1; // Default to -1 if selectedRow is null
     }
 
     onColorChange(index: number, newColor: string): void {
+        const row = this.rows[index];
+        const oldColor = row.selectedColor;
+        row.selectedColor = newColor;
+
+        // Update only if this row has coordinates
+        const affectedCoords = this.colorCoordinateService.getCoordinatesForRow(index);
+        this.colorCoordinateService.updateColorForCells(oldColor, newColor, affectedCoords);
+
         this.rows[index].selectedColor = newColor;
+
+        if (this.selectedRow === index) {
+            this.colorCoordinateService.setColor(newColor);
+        }
     }
+
+
 }

--- a/src/app/tableTwo.component.html
+++ b/src/app/tableTwo.component.html
@@ -1,8 +1,9 @@
 <h2 *ngIf="selectedCell">Selected Cell: {{ selectedCell }}</h2>
-<table class="excel-table">
+<table class="excel-table" style="page-break-before: always;">
     <tr *ngFor="let rowIndex of rows; let r = index">
-        <td *ngFor="let colName of cols; let c = index" [class.header]="r === 0 || c === 0"
-            (click)="r !== 0 && c !== 0 ? selectCell(r, c) : null">
+        <td *ngFor="let colName of cols; let c = index"
+            [style.backgroundColor]="colorCoordinateService.getCellColor[r + ',' + c] || 'white'"
+            [class.header]="r === 0 || c === 0" (click)="r !== 0 && c !== 0 ? selectCell(r, c) : null">
             <!-- Top-left corner -->
             <ng-container *ngIf="r === 0 && c === 0"> </ng-container>
 

--- a/src/app/tableTwo.component.ts
+++ b/src/app/tableTwo.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { NgForOf, TitleCasePipe, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-
+import { ColorCoordinateService } from './color-coordinate.service';
 
 @Component({
     selector: 'app-table2',
@@ -16,6 +16,9 @@ export class TableTwoComponent implements OnChanges {
     colCount: number = 0;
     rows: number[] = [];
     cols: string[] = [];
+    cellColors: { [key: string]: string } = {};
+
+    constructor(private colorCoordinateService: ColorCoordinateService) { }
 
     ngOnChanges(changes: SimpleChanges): void {
         if (this.inputData && this.inputData.length >= 2) {
@@ -48,10 +51,19 @@ export class TableTwoComponent implements OnChanges {
     }
 
     selectedCell: string = ''; // Holds the selected cell label (e.g., "AB20")
+
     // Method to handle the cell click and update the selected cell message
     selectCell(rowIndex: number, colIndex: number): void {
+        const color = this.colorCoordinateService.getColor();
+        this.cellColors[`${rowIndex},${colIndex}`] = color;
         const colLabel = this.cols[colIndex];
         this.selectedCell = `${colLabel}${rowIndex}`; // Set message like "AB20"
+
+        // Get the active row from Table One
+        const rowIndexInTableOne = this.colorCoordinateService.getTableOneRowIndex();
+
+        // Send this coordinate to service
+        this.colorCoordinateService.addCoordinateToRow(rowIndexInTableOne, this.selectedCell);
     }
 
 }


### PR DESCRIPTION
Added the following functionality:

Selecting a color in the upper table now marks a color as "Active". When a cell in the lower table is clicked, it is colored with the "Active" color.  

When a cell in the lower table is clicked, its coordinate is added to the right column by the color name.  For example, if cells A1, B2, and C3 are colored "red" then the row with "red" as the selected color will show "A1, B2, C3" in the right cell.  Keep the cells in lexicographic order (Sort by letter First, Number Second).  

Still TODO:
* When a drop-down is changed to a new color, all of the cells in the table change from the old color to the new color.  
* Add hex values
* Also need to clear the tables if the user decides to submit the form with new row, col, and color selections. 